### PR TITLE
build(deps): bump Syncfusion.SfTreeView.WPF from 20.1.0.47 to 20.1.0.52

### DIFF
--- a/shadowsocks-csharp/shadowsocksr.csproj
+++ b/shadowsocks-csharp/shadowsocksr.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="RunAtStartup" Version="5.0.2" />
     <PackageReference Include="Shadowsocks.Protocol" Version="1.0.0" />
     <PackageReference Include="Syncfusion.SfGrid.WPF" Version="20.1.0.47" />
-    <PackageReference Include="Syncfusion.SfTreeView.WPF" Version="20.1.0.47" />
+    <PackageReference Include="Syncfusion.SfTreeView.WPF" Version="20.1.0.52" />
     <PackageReference Include="URIScheme" Version="5.0.0" />
     <PackageReference Include="WindowsProxy" Version="5.0.6" />
     <PackageReference Include="WpfColorFontDialog" Version="1.0.8" />


### PR DESCRIPTION
Bumps Syncfusion.SfTreeView.WPF from 20.1.0.47 to 20.1.0.52.

---
updated-dependencies:
- dependency-name: Syncfusion.SfTreeView.WPF
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>